### PR TITLE
fix: Update mintNft API using proper format

### DIFF
--- a/README.md
+++ b/README.md
@@ -646,7 +646,7 @@ Example:
 | Param                            | Description                                            |
 | -------------------------------- | ------------------------------------------------------ |
 | `token_id`                       | _ID for new token you are minting_                     |
-| `metadata`                       | _Metadata for the new token as a string._              |
+| `token_metadata`                 | _TokenMetadata for the new token as an object._        |
 | `account_id`                     | _Account ID for the new token owner._                  |
 | `seed_phrase` _OR_ `private_key` | _Seed phrase OR private key for the NFT contract._     |
 | `nft_contract`                   | _Account ID for the NFT contract your are minting on._ |
@@ -658,7 +658,7 @@ Example:
 ```
 {
     "token_id": "EXAMPLE-TOKEN",
-    "metadata": "https://ipfs.io/ipfs/Qme7ss3ARVgxv6rXqVPiikMJ8u2NLgmgszg13pYrDKEoiu",
+    "token_metadata": {"media":"https://ipfs.io/ipfs/Qme7ss3ARVgxv6rXqVPiikMJ8u2NLgmgszg13pYrDKEoiu"},
     "account_id": "example.testnet",
     "private_key": "41oHMLtYygTsgwDzaMdjWRq48Sy9xJsitJGmMxgA9A7nvd65aT8vQwAvRdHi1nruPP47B6pNhW5T5TK8SsqCZmjn",
     "contract": "nft.example.near",

--- a/app.js
+++ b/app.js
@@ -281,11 +281,11 @@ const init = async () => {
             for (let i = min; i <= max; i++) {
                 const tokenId = request.payload.token_id.replace('{inc}', i);
 
-                let {account_id, private_key, metadata, contract} = request.payload;
+                let {account_id, private_key, token_metadata, contract} = request.payload;
 
                 const tx = await token.MintNFT(
                     tokenId,
-                    metadata,
+                    token_metadata,
                     contract,
                     account_id,
                     private_key

--- a/token.js
+++ b/token.js
@@ -25,7 +25,7 @@ module.exports = {
     /**
      * @return {string}
      */
-    MintNFT: async function (tokenId, metadata, contractAccountId, account_id, private_key) {
+    MintNFT: async function (tokenId, tokenMetadata, contractAccountId, account_id, private_key) {
         const nftContract = contractAccountId ? contractAccountId : settings.nft_contract;
 
         let account = !(account_id && private_key)
@@ -38,7 +38,8 @@ module.exports = {
                 "nft_mint",
                 {
                     "token_id": tokenId,
-                    "metadata": metadata
+                    "token_metadata": tokenMetadata,
+                    "receiver_id": account_id
                 },
                 '100000000000000',
                 '10000000000000000000000');


### PR DESCRIPTION
## Summary

- Update mintNft API using proper format 
- Update mint_nft example in README

I came across this [StackOverflow](https://stackoverflow.com/questions/71028781/getting-500-internal-server-error-when-calling-mint-nft-near-rest-api) question, and started debugging. It looks like the current `/mint_nft`-API doesn't add `receiver_id` to the functionCall, and is using the incorrect name and format for `metadata`. This PR addresses this. I hope this PR can be helpful. The current way of calling `functionCall` is deprecated, but this small change will hopefully make the current `/mint_nft` example work.

I ran the server and tested the API using curl command:
```
curl --header "Content-Type: application/json" -d '{"token_id": "example_id", "token_metadata": {"media":"https://ipfs.io/ipfs/Qme7ss3ARVgxv6rXqVPiikMJ8u2NLgmgszg13pYrDKEoiu"},"account_id": "example.testnet","private_key": "somePrivateKey","contract": "example.testnet"}' -X POST http://localhost:3000/mint_nft
```